### PR TITLE
Require linux-surface kernel

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,6 +7,7 @@ arch=(any)
 pkgdesc="Firmware override for Surface devices with QCA6174 ATH10K WiFi Chip"
 url="http://github.com/linux-surface/ath10k-firmware-override"
 license=('custom')
+depends=('linux-surface')
 
 source=(
     board.bin

--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,6 @@ Build-Depends:
  dh-exec
 
 Package: surface-ath10k-firmware-override
+Depends: linux-image-surface
 Architecture: all
 Description: Firmware override for Surface devices with QCA6174 ATH10K WiFi chip

--- a/surface-ath10k-firmware-override.spec
+++ b/surface-ath10k-firmware-override.spec
@@ -12,6 +12,8 @@ License: proprietary
 Source0: board.bin
 Source1: ath10k.conf
 
+Requires: kernel-surface
+
 %description
 Firmware override for Surface devices with QCA6174 ATH10K WiFi chip,
 specifically the Surface Go series and AMD Surface Laptops.


### PR DESCRIPTION
The patch that allows overriding the ath10k firmware file is not upstream, so the linux-surface kernel needs to be installed for this package to work.